### PR TITLE
fix: removes android warning using event emitter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           
   build-sample-app-ios:
     macos:
-      xcode: "12.0.1"
+      xcode: "12.1.0"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           
   build-sample-app-ios:
     macos:
-      xcode: "12.1.0"
+      xcode: "12.0.1"
 
     steps:
       - checkout

--- a/packages/optimize/README.md
+++ b/packages/optimize/README.md
@@ -49,7 +49,7 @@ iOS
 @implementation AppDelegate
 -(BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [AEPMobileCore setLogLevel: AEPLogLevelTrace];
-  [AEPMobileCore registerExtensions: @[AEPMobileEdge.class, AEPMobileEdgeIdentity.class AEPMobileOptimize.class] completion:^{
+  [AEPMobileCore registerExtensions: @[AEPMobileEdge.class, AEPMobileEdgeIdentity.class, AEPMobileOptimize.class] completion:^{
     [AEPMobileCore configureWithAppId:@"yourAppID"];
     [AEPMobileCore lifecycleStart:@{@"contextDataKey": @"contextDataVal"}];
   }

--- a/packages/optimize/android/src/main/java/com/adobe/marketing/mobile/reactnative/optimize/RCTAEPOptimizeModule.java
+++ b/packages/optimize/android/src/main/java/com/adobe/marketing/mobile/reactnative/optimize/RCTAEPOptimizeModule.java
@@ -182,6 +182,14 @@ public class RCTAEPOptimizeModule extends ReactContextBaseJavaModule {
         }
     }
 
+    // Required for React Native built in EventEmitter Calls.
+    @ReactMethod
+    public void addListener(String eventName) {}
+
+    // Required for React Native built in EventEmitter Calls.
+    @ReactMethod
+    public void removeListeners(Integer count) {}
+
     private static Offer createOffer(Map<String, Object> offerEventData) {
         String id = (String) offerEventData.get("id");
         String type = (String) offerEventData.get("type");


### PR DESCRIPTION
## Description

This is a small fix that removes a console warning on android apps due to the package not having add and remove listener functions react native looks for in android. Functionality is not affected.

## Screenshots (if appropriate):

Previous warning:
<img width="581" alt="image" src="https://user-images.githubusercontent.com/18382782/179813719-fd04a749-7cf2-4e5b-99ab-06ca41394c6d.png">


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
