### PR TITLE
[android12] add android:exported attribute to core extension's manifest 

### DIFF
--- a/apps/AEPSampleApp/android/build.gradle
+++ b/apps/AEPSampleApp/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.3"
         minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        compileSdkVersion = 31
+        targetSdkVersion = 31
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -12,12 +12,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 //    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/packages/core/android/src/main/AndroidManifest.xml
+++ b/packages/core/android/src/main/AndroidManifest.xml
@@ -1,9 +1,13 @@
-
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.adobe.marketing.mobile.reactnative">
+    package="com.adobe.marketing.mobile.reactnative">
+
     <application>
-       <activity android:name="com.adobe.marketing.mobile.FullscreenMessageActivity" />
-       <receiver android:name="com.adobe.marketing.mobile.LocalNotificationHandler" />
-   </application>
+        <activity
+            android:name="com.adobe.marketing.mobile.FullscreenMessageActivity"
+            android:exported="false" />
+        <receiver
+            android:name="com.adobe.marketing.mobile.LocalNotificationHandler"
+            android:exported="false" />
+    </application>
 </manifest>
   


### PR DESCRIPTION
Adding the `android:exported` attribute to the Android manifest file in order to meet the Android requirement when targeting API level 31+. For more details see: https://github.com/adobe/react-native-acpcore/issues/129