### PR TITLE
Circleci update xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,15 @@ jobs:
           
   build-sample-app-ios:
     macos:
-      xcode: "12.0.1"
+      xcode: "13.0.0"
 
     steps:
       - checkout
+
+      # CircleCI puts xcode app in consistent path, RN looks for versioned path
+      - run:
+          name: Move xcode
+          command: cd /Applications && mv Xcode.app Xcode-13.0.app
 
       - run:
           name: Install latest NodeJS
@@ -66,7 +71,7 @@ jobs:
           command: sudo gem install cocoapods
           
       - run:
-          name: install pods
+          name: Install pods
           command: yarn sampleapp:ios:pod:install
 
       - run:


### PR DESCRIPTION
## Description

Updates circleci xcode build version to 13, adds workaround to deal with circleci xcode naming. See linked issue for details.

## Related Issue

https://github.com/adobe/aepsdk-react-native/issues/196

## Motivation and Context

The current xcode version in the build will be deprecated on Aug 2, and all ios builds will fail afterwards.

## How Has This Been Tested?

Ran successfully in CircleCI!

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
