### PR TITLE
bring ios sample app back to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,11 +83,8 @@ jobs:
 
       - run:
           name: Building iOS Sample App cd
-          command: cd apps/AEPSampleApp
+          command: cd apps/AEPSampleApp && npx react-native run-ios --verbose
 
-      - run:
-           name: Building iOS Sample App npx 
-           command: npx react-native run-ios --verbose
 workflows:
   version: 2.1
   ci-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,10 +86,6 @@ jobs:
           command: cd apps/AEPSampleApp
 
       - run:
-          name: Building iOS Sample App cd
-          command: rm -rf ~/Library/Developer/Xcode/DerivedData
-
-      - run:
            name: Building iOS Sample App npx 
            command: npx react-native run-ios --verbose
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,8 +82,8 @@ jobs:
             rm -rf ~/Library/Developer/Xcode/DerivedData
 
       - run:
-          name: Building iOS Sample App cd
-          command: yarn sampleapp:ios:build
+          name: Building iOS Sample App
+          command: cd apps/AEPSampleApp && npx react-native run-ios --verbose
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,5 +90,5 @@ workflows:
     jobs:
       - unit-test
       # Uncomment the following lines to build the ios code after this issue is fixed: https://github.com/adobe/aepsdk-react-native/issues/272
-      # - build-sample-app-ios
+      - build-sample-app-ios
       - build-sample-app-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
 
       - run:
           name: Building iOS Sample App cd
-          command: cd apps/AEPSampleApp && npx react-native run-ios --verbose
+          command: yarn sampleapp:ios:build
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,8 +82,16 @@ jobs:
             rm -rf ~/Library/Developer/Xcode/DerivedData
 
       - run:
-          name: Building iOS Sample App
-          command: yarn sampleapp:ios:build
+          name: Building iOS Sample App cd
+          command: cd apps/AEPSampleApp
+
+      - run:
+          name: Building iOS Sample App cd
+          command: rm -rf ~/Library/Developer/Xcode/DerivedData
+
+      - run:
+           name: Building iOS Sample App npx 
+           command: npx react-native run-ios --verbose
 workflows:
   version: 2.1
   ci-workflow:

--- a/apps/AEPSampleApp/ios/AEPSampleApp.xcodeproj/project.pbxproj
+++ b/apps/AEPSampleApp/ios/AEPSampleApp.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		};
 		E235C05ADACE081382539298 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/apps/AEPSampleApp/ios/AEPSampleApp.xcodeproj/project.pbxproj
+++ b/apps/AEPSampleApp/ios/AEPSampleApp.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -378,6 +379,7 @@
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/apps/AEPSampleApp/ios/AEPSampleApp.xcodeproj/project.pbxproj
+++ b/apps/AEPSampleApp/ios/AEPSampleApp.xcodeproj/project.pbxproj
@@ -344,7 +344,6 @@
 		};
 		E235C05ADACE081382539298 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/apps/AEPSampleApp/ios/Podfile
+++ b/apps/AEPSampleApp/ios/Podfile
@@ -28,7 +28,7 @@ target 'AEPSampleApp' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable the next line.
-  use_flipper!()
+  #use_flipper!()
 
   post_install do |installer|
     react_native_post_install(installer)

--- a/apps/AEPSampleApp/ios/Podfile
+++ b/apps/AEPSampleApp/ios/Podfile
@@ -28,7 +28,7 @@ target 'AEPSampleApp' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable the next line.
-  #use_flipper!()
+  use_flipper!()
 
   post_install do |installer|
     react_native_post_install(installer)


### PR DESCRIPTION
bring ios sample app back to ci

- unchecked "Based on dependency analysis" in the Xcode build phrase to dismiss the build error.
- Calling react-native run-ios command directly instead of from yarn script 

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
