### PR TITLE
Extends TargetRequests with content and (meta)data callback

### DIFF
--- a/packages/target/README.md
+++ b/packages/target/README.md
@@ -261,6 +261,48 @@ var parameters = new TargetParameters(
 Target.retrieveLocationContent(locationRequests, parameters);
 ```
 
+### Load Target requests with metadata:
+
+**Syntax**
+
+```typescript
+retrieveLocationContent(Array<TargetRequestObject>, <TargetParameters>): void
+```
+
+**Example**
+
+```typescript
+var mboxParameters = { status: "platinum" };
+var purchaseIDs = ["34", "125"];
+
+var targetOrder = new TargetOrder("ADCKKIM", 344.3, purchaseIDs);
+var targetProduct = new TargetProduct("24D3412", "Books");
+var parameters = new TargetParameters(mboxParameters, null, null, null);
+var requestWithData = new TargetRequestObjectWithData(
+  "mboxNameWithData",
+  parameters,
+  "defaultContent",
+  (error, content, data) => {
+    if (error) {
+      console.error(error);
+    } else {
+      console.log("Adobe content and data:", content, data);
+    }
+  }
+);
+
+var locationRequests = [requestWithData];
+var profileParameters = { ageGroup: "20-32" };
+
+var parameters = new TargetParameters(
+  { parameters: "parametervalue" },
+  profileParameters,
+  targetProduct,
+  targetOrder
+);
+Target.retrieveLocationContent(locationRequests, parameters);
+```
+
 ### Using the prefetch APIs:
 
 **Syntax**

--- a/packages/target/android/src/main/java/com/adobe/marketing/mobile/reactnative/target/RCTAEPTargetMapUtil.java
+++ b/packages/target/android/src/main/java/com/adobe/marketing/mobile/reactnative/target/RCTAEPTargetMapUtil.java
@@ -107,7 +107,8 @@ public class RCTAEPTargetMapUtil {
             } else if (value instanceof String) {
                 writableMap.putString((String) pair.getKey(), (String) value);
             } else if (value instanceof Map) {
-                writableMap.putMap((String) pair.getKey(), RCTAEPTargetMapUtil.toWritableMap((Map<String, Object>) value));
+                // wrapped value in HashMap to ensure it is mutable
+                writableMap.putMap((String) pair.getKey(), RCTAEPTargetMapUtil.toWritableMap((new HashMap<>((Map<String, Object>) value))));
             } else if (value.getClass() != null && value.getClass().isArray()) {
                 writableMap.putArray((String) pair.getKey(), RCTAEPTargetArrayUtil.toWritableArray((Object[]) value));
             }

--- a/packages/target/android/src/main/java/com/adobe/marketing/mobile/reactnative/target/RCTAEPTargetModule.java
+++ b/packages/target/android/src/main/java/com/adobe/marketing/mobile/reactnative/target/RCTAEPTargetModule.java
@@ -182,4 +182,10 @@ public class RCTAEPTargetModule extends ReactContextBaseJavaModule {
     registeredTargetRequests.put(requestMap.getString(REQUEST_ID_KEY), request);
   }
 
+@ReactMethod
+  public void registerTargetRequestsWithData(ReadableMap requestMap, Callback successCallback) {
+    TargetRequest request = RCTAEPTargetDataBridge.mapToRequestWithData(requestMap, successCallback);
+    registeredTargetRequests.put(requestMap.getString(REQUEST_ID_KEY), request);
+  }
+
 }

--- a/packages/target/ios/src/AEPTargetRequestObjectDataBridge.h
+++ b/packages/target/ios/src/AEPTargetRequestObjectDataBridge.h
@@ -13,11 +13,17 @@
 @import AEPTarget;
 #import "AEPTargetRequestObjectDataBridge.h"
 
+typedef void (^TargetRequestCallbackWithData)(NSString * _Nullable, NSDictionary<NSString *,id> * _Nullable);
+
 @interface AEPTargetRequestObject (RCTBridge)
 
 + (AEPTargetRequestObject *)
     targetRequestObjectFromDict:(NSDictionary *)dict
                        callback:(nullable void (^)(
                                     NSString *__nullable content))callback;
+
++ (AEPTargetRequestObject *)
+    targetRequestObjectWithDataFromDict:(NSDictionary *)dict
+        contentWithDataCallback:(TargetRequestCallbackWithData)contentWithDataCallback;
 
 @end

--- a/packages/target/ios/src/AEPTargetRequestObjectDataBridge.m
+++ b/packages/target/ios/src/AEPTargetRequestObjectDataBridge.m
@@ -33,4 +33,23 @@ NSString *const DEFAULT_CONTENT_KEY = @"defaultContent";
           initWithMboxName:dict[REQUEST_NAME_KEY] defaultContent:dict[DEFAULT_CONTENT_KEY] targetParameters:parameters contentCallback:callback];
 }
 
++ (AEPTargetRequestObject *)
+    targetRequestObjectWithDataFromDict:(NSDictionary *)dict
+        contentWithDataCallback: (TargetRequestCallbackWithData) contentWithDataCallback {
+    
+  if (!dict || [dict isEqual:[NSNull null]]) {
+    return nil;
+  }
+
+  AEPTargetParameters *parameters = [AEPTargetParameters
+    targetParametersFromDict:dict[REQUEST_PARAMETERS_KEY]];
+    
+  return [[AEPTargetRequestObject alloc]
+          initWithMboxName:dict[REQUEST_NAME_KEY]
+          defaultContent:dict[DEFAULT_CONTENT_KEY]
+          targetParameters:parameters
+          contentWithDataCallback: contentWithDataCallback
+  ];
+}
+
 @end

--- a/packages/target/ios/src/RCTAEPTarget.m
+++ b/packages/target/ios/src/RCTAEPTarget.m
@@ -166,4 +166,24 @@ RCT_EXPORT_METHOD(registerTargetRequests
   _registeredTargetRequests[requestDict[@"id"]] = obj;
 }
 
+RCT_EXPORT_METHOD(registerTargetRequestsWithData
+                  : (nonnull NSDictionary *)requestDict callback
+                  : (RCTResponseSenderBlock)callback) {
+    
+ TargetRequestCallbackWithData contentWithDataCallback = ^void(NSString * _Nullable content, NSDictionary<NSString *,id> * _Nullable data) {
+     NSDictionary *test = [[NSDictionary alloc] initWithDictionary: data];
+     callback(@[ [NSNull null], content, test]);
+ };
+    
+  AEPTargetRequestObject *obj = [AEPTargetRequestObject
+             targetRequestObjectWithDataFromDict:requestDict
+                                 contentWithDataCallback: contentWithDataCallback];
+
+  if (!_registeredTargetRequests) {
+    _registeredTargetRequests = [NSMutableDictionary dictionary];
+  }
+
+  _registeredTargetRequests[requestDict[@"id"]] = obj;
+}
+
 @end

--- a/packages/target/ts/index.ts
+++ b/packages/target/ts/index.ts
@@ -15,6 +15,7 @@ import TargetParameters from './models/TargetParameters';
 import TargetPrefetchObject from './models/TargetPrefetchObject';
 import TargetProduct from './models/TargetProduct';
 import TargetRequestObject from './models/TargetRequestObject';
+import TargetRequestObjectWithData from './models/TargetRequestObjectWithData';
 
 export {
   // Native models
@@ -23,6 +24,7 @@ export {
   TargetPrefetchObject,
   TargetProduct,
   TargetRequestObject,
+  TargetRequestObjectWithData,
   // Native modules
   Target
 };

--- a/packages/target/ts/models/TargetRequestObjectWithData.ts
+++ b/packages/target/ts/models/TargetRequestObjectWithData.ts
@@ -17,20 +17,20 @@ export type TargetDataCallback = (
   error: Error | null,
   content: string | null,
   data: Record<string, any>
-) => void
+) => void;
 
 interface ITargetRequests {
   registerTargetRequestsWithData: (
     requestMap: TargetRequestObjectWithData,
     callback: TargetDataCallback
-  ) => void
+  ) => void;
 }
 
-const RCTTarget: ITargetRequests = NativeModules.AEPTarget
+const RCTTarget: ITargetRequests = NativeModules.AEPTarget;
 
 class TargetRequestObjectWithData extends TargetPrefetchObject {
-  defaultContent: string
-  id: string
+  defaultContent: string;
+  id: string;
 
   constructor(
     name: string,
@@ -38,12 +38,12 @@ class TargetRequestObjectWithData extends TargetPrefetchObject {
     defaultContent: string,
     callback: TargetDataCallback
   ) {
-    super(name, targetParameters)
+    super(name, targetParameters);
 
-    this.defaultContent = defaultContent
-    this.id = '_' + Math.random().toString(36).substr(2, 9)
+    this.defaultContent = defaultContent;
+    this.id = "_" + Math.random().toString(36).substr(2, 9);
 
-    RCTTarget.registerTargetRequestsWithData(this, callback)
+    RCTTarget.registerTargetRequestsWithData(this, callback);
   }
 }
 

--- a/packages/target/ts/models/TargetRequestObjectWithData.ts
+++ b/packages/target/ts/models/TargetRequestObjectWithData.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import TargetPrefetchObject from './TargetPrefetchObject';
+import TargetParameters from './TargetParameters';
+import { NativeModules } from 'react-native';
+
+export type TargetDataCallback = (
+  error: Error | null,
+  content: string | null,
+  data: Record<string, any>
+) => void
+
+interface ITargetRequests {
+  registerTargetRequestsWithData: (
+    requestMap: TargetRequestObjectWithData,
+    callback: TargetDataCallback
+  ) => void
+}
+
+const RCTTarget: ITargetRequests = NativeModules.AEPTarget
+
+class TargetRequestObjectWithData extends TargetPrefetchObject {
+  defaultContent: string
+  id: string
+
+  constructor(
+    name: string,
+    targetParameters: TargetParameters,
+    defaultContent: string,
+    callback: TargetDataCallback
+  ) {
+    super(name, targetParameters)
+
+    this.defaultContent = defaultContent
+    this.id = '_' + Math.random().toString(36).substr(2, 9)
+
+    RCTTarget.registerTargetRequestsWithData(this, callback)
+  }
+}
+
+export default TargetRequestObjectWithData;

--- a/tests/jest/setup.ts
+++ b/tests/jest/setup.ts
@@ -128,7 +128,8 @@ jest.doMock('react-native', () => {
                     prefetchContent: jest.fn(() => new Promise(resolve => resolve(''))),
                     displayedLocations: jest.fn(),
                     clickedLocation: jest.fn(),
-                    registerTargetRequests: jest.fn()
+                    registerTargetRequests: jest.fn(),
+                    registerTargetRequestsWithData: jest.fn()
                 },   
                 AEPPlaces: {
                     extensionVersion: jest.fn(() => new Promise(resolve => resolve(''))),


### PR DESCRIPTION
Exposes the native content with metadata callback to React Native. Currently it is not possible to retrieve the `responseTokens` or `analytics payload` as described [for Android](https://github.com/adobe/aepsdk-target-android/blob/main/Documentation/api-reference.md#adobetargetdetailedcallback) and [for iOS](https://github.com/adobe/aepsdk-target-android/blob/main/Documentation/api-reference.md#adobetargetdetailedcallback).

## Description

**Added**
- a new `TargetRequestObjectWithData` which registers a callback containing both the content, data and error.
- both native iOS and Android implementations to expose the `contentWithDataCallback` to RN

## Related Issue

Exposes additional already existing native SDK functionality.

## Motivation and Context

Currently it is not possible to retrieve any additional (meta)data from a `TargetRequest`.

## How Has This Been Tested?

Added unit tests and tested this with assurance in an existing project.
Tracked the Target requests and its metadata. Added an analytics edge event to track this data.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
