### PR TITLE
Update dispatchEventWithResponseCallback API with timeout param

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,11 +27,13 @@ body:
     label: Environment
     description: |
       Please provide the Platform, OS version, SDK version(s) used, IDE version, and any other specific settings that could help us narrow down the problem.
+      Run `npx react-native info` and paste the output here.
       Example:
-        - **Platform**: React Native
-        - **OS**: Android 13
-        - **SDK(s)**: Edge, EdgeIdentity, EdgeConsent
-        - **IDE**: Android Studio 2021.3.1 Patch 1, vscode 1.87.2
+        System:
+          OS: macOS 14.2.1
+          CPU: (10) arm64 Apple M1 Max
+          Memory: 47.45 MB / 25.00 GB
+
   validations:
     required: true
 

--- a/apps/AEPSampleApp/android/build.gradle
+++ b/apps/AEPSampleApp/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "34.0.0"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33

--- a/apps/AEPSampleApp/extensions/CoreView.tsx
+++ b/apps/AEPSampleApp/extensions/CoreView.tsx
@@ -51,7 +51,7 @@ function dispatchEventWithResponseCallback() {
   var event = new Event('eventName', 'eventType', 'eventSource', {
     testDataKey: 'testDataValue',
   });
-  MobileCore.dispatchEventWithResponseCallback(event, 1000).then(responseEvent =>
+  MobileCore.dispatchEventWithResponseCallback(event, 1500).then(responseEvent =>
     console.log('AdobeExperienceSDK: responseEvent = ' + responseEvent),
   );
 }

--- a/apps/AEPSampleApp/extensions/CoreView.tsx
+++ b/apps/AEPSampleApp/extensions/CoreView.tsx
@@ -40,11 +40,18 @@ function collectPii() {
   MobileCore.collectPii({myPii: 'data'});
 }
 
+function dispatchEvent() {
+  var event = new Event('eventName', 'eventType', 'eventSource', {
+    testDataKey: 'testDataValue',
+  });
+  MobileCore.dispatchEvent(event);
+}
+
 function dispatchEventWithResponseCallback() {
   var event = new Event('eventName', 'eventType', 'eventSource', {
     testDataKey: 'testDataValue',
   });
-  MobileCore.dispatchEventWithResponseCallback(event).then(responseEvent =>
+  MobileCore.dispatchEventWithResponseCallback(event, 1000).then(responseEvent =>
     console.log('AdobeExperienceSDK: responseEvent = ' + responseEvent),
   );
 }
@@ -136,6 +143,7 @@ const CoreView = ({navigation}: NavigationProps) => {
         <Button title="collectPii()" onPress={collectPii} />
         <Button title="trackAction()" onPress={trackAction} />
         <Button title="trackState()" onPress={trackState} />
+        <Button title="dispatchEvent()" onPress={dispatchEvent} />
         <Button
           title="dispatchEventWithResponseCallback()"
           onPress={dispatchEventWithResponseCallback}

--- a/apps/AEPSampleApp/extensions/EdgeView.tsx
+++ b/apps/AEPSampleApp/extensions/EdgeView.tsx
@@ -101,7 +101,7 @@ const EdgeView = ({navigation}: NavigationProps) => {
       if (hint == null) {
        locationStr = "null";
       }
-      getlocationHintText(locationStr);
+      getlocationHintText(locationStr || '');
     });
   }
 

--- a/packages/core/__tests__/MobileCoreTests.ts
+++ b/packages/core/__tests__/MobileCoreTests.ts
@@ -86,7 +86,7 @@ describe('MobileCore', () => {
       testDataKey: 'testDataValue'
     });
     await MobileCore.dispatchEventWithResponseCallback(testEvent, 5000);
-    expect(spy).toHaveBeenCalledWith(testEvent);
+    expect(spy).toHaveBeenCalledWith(testEvent, 5000);
   });
 
   it('trackAction is called with correct parameters', async () => {

--- a/packages/core/__tests__/MobileCoreTests.ts
+++ b/packages/core/__tests__/MobileCoreTests.ts
@@ -68,6 +68,15 @@ describe('MobileCore', () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it('dispatchEvent is called with correct parameters', async () => {
+    const spy = jest.spyOn(NativeModules.AEPCore, 'dispatchEvent');
+    let testEvent = new Event('eventName', 'eventType', 'eventSource', {
+      testDataKey: 'testDataValue'
+    });
+    await MobileCore.dispatchEvent(testEvent);
+    expect(spy).toHaveBeenCalledWith(testEvent);
+  });
+
   it('dispatchEventWithResponseCallback is called with correct parameters', async () => {
     const spy = jest.spyOn(
       NativeModules.AEPCore,
@@ -76,7 +85,7 @@ describe('MobileCore', () => {
     let testEvent = new Event('eventName', 'eventType', 'eventSource', {
       testDataKey: 'testDataValue'
     });
-    await MobileCore.dispatchEventWithResponseCallback(testEvent);
+    await MobileCore.dispatchEventWithResponseCallback(testEvent, 5000);
     expect(spy).toHaveBeenCalledWith(testEvent);
   });
 

--- a/packages/core/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTAEPCoreModule.java
+++ b/packages/core/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTAEPCoreModule.java
@@ -131,7 +131,6 @@ public class RCTAEPCoreModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-
     public void dispatchEventWithResponseCallback(final ReadableMap eventMap, final int timeout, final Promise promise) {
         Event event = RCTAEPCoreDataBridge.eventFromReadableMap(eventMap);
         if (event == null) {
@@ -139,11 +138,6 @@ public class RCTAEPCoreModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        if (timeout <= 0) {
-            promise.reject(getName(), INVALID_TIMEOUT_VALUE_MESSAGE, new Error(INVALID_TIMEOUT_VALUE_MESSAGE));
-            return;
-        }
- 
         MobileCore.dispatchEventWithResponseCallback(event, timeout, new AdobeCallbackWithError<Event>(){
             @Override
             public void fail(AdobeError adobeError) {

--- a/packages/core/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTAEPCoreModule.java
+++ b/packages/core/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTAEPCoreModule.java
@@ -119,16 +119,26 @@ public class RCTAEPCoreModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-
-    public void dispatchEventWithResponseCallback(final ReadableMap eventMap,
-                                                  final Promise promise) {
+    public void dispatchEvent(final ReadableMap eventMap, final Promise promise) {
         Event event = RCTAEPCoreDataBridge.eventFromReadableMap(eventMap);
         if (event == null) {
             promise.reject(getName(), FAILED_TO_CONVERT_EVENT_MESSAGE, new Error(FAILED_TO_CONVERT_EVENT_MESSAGE));
             return;
         }
 
-        MobileCore.dispatchEventWithResponseCallback(event, 5000, new AdobeCallbackWithError<Event>(){
+        MobileCore.dispatchEvent(event);
+    }
+
+    @ReactMethod
+
+    public void dispatchEventWithResponseCallback(final ReadableMap eventMap, final int timeout, final Promise promise) {
+        Event event = RCTAEPCoreDataBridge.eventFromReadableMap(eventMap);
+        if (event == null) {
+            promise.reject(getName(), FAILED_TO_CONVERT_EVENT_MESSAGE, new Error(FAILED_TO_CONVERT_EVENT_MESSAGE));
+            return;
+        }
+
+        MobileCore.dispatchEventWithResponseCallback(event, timeout, new AdobeCallbackWithError<Event>(){
             @Override
             public void fail(AdobeError adobeError) {
                 handleError(promise, adobeError, "dispatchEventWithResponseCallback");

--- a/packages/core/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTAEPCoreModule.java
+++ b/packages/core/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTAEPCoreModule.java
@@ -34,6 +34,7 @@ public class RCTAEPCoreModule extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext reactContext;
     private static String FAILED_TO_CONVERT_EVENT_MESSAGE = "Failed to convert map to Event";
+    private static String INVALID_TIMEOUT_VALUE_MESSAGE = "Invalid timeout value. Timeout must be a positive integer.";
     private static AtomicBoolean hasStarted = new AtomicBoolean(false);
 
     public RCTAEPCoreModule(ReactApplicationContext reactContext) {
@@ -138,6 +139,11 @@ public class RCTAEPCoreModule extends ReactContextBaseJavaModule {
             return;
         }
 
+        if (timeout <= 0) {
+            promise.reject(getName(), INVALID_TIMEOUT_VALUE_MESSAGE, new Error(INVALID_TIMEOUT_VALUE_MESSAGE));
+            return;
+        }
+ 
         MobileCore.dispatchEventWithResponseCallback(event, timeout, new AdobeCallbackWithError<Event>(){
             @Override
             public void fail(AdobeError adobeError) {

--- a/packages/core/ios/src/Core/RCTAEPCore.m
+++ b/packages/core/ios/src/Core/RCTAEPCore.m
@@ -119,14 +119,23 @@ RCT_EXPORT_METHOD(trackState: (nullable NSString*) state data: (nullable NSDicti
     [AEPMobileCore trackState:state data:data];
 }
 
-RCT_EXPORT_METHOD(dispatchEventWithResponseCallback: (nonnull NSDictionary*) requestEventDict resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(dispatchEvent: (nonnull NSDictionary*) eventDict resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+     AEPEvent *event = [RCTAEPCoreDataBridge eventFromDictionary:eventDict];
+     if (!event) {
+         reject(EXTENSION_NAME, FAILED_TO_CONVERT_EVENT_MESSAGE, nil);
+         return;
+     }
+     [AEPMobileCore dispatch:event];
+ }
+
+RCT_EXPORT_METHOD(dispatchEventWithResponseCallback: (nonnull NSDictionary*) requestEventDict withTimeout:(nonnull NSNumber*) timeout resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     AEPEvent *requestEvent = [RCTAEPCoreDataBridge eventFromDictionary:requestEventDict];
     if (!requestEvent) {
         reject(EXTENSION_NAME, FAILED_TO_CONVERT_EVENT_MESSAGE, nil);
         return;
     }
 
-    [AEPMobileCore dispatch:requestEvent timeout:1 responseCallback:^(AEPEvent * _Nullable responseEvent) {
+    [AEPMobileCore dispatch:requestEvent timeout:[timeout doubleValue] responseCallback:^(AEPEvent * _Nullable responseEvent) {
         resolve([RCTAEPCoreDataBridge dictionaryFromEvent:responseEvent]);
     }];
 }

--- a/packages/core/ts/MobileCore.ts
+++ b/packages/core/ts/MobileCore.ts
@@ -24,7 +24,8 @@ interface IMobileCore {
   setPrivacyStatus: (privacyStatus: PrivacyStatus) => void;
   getPrivacyStatus: () => Promise<PrivacyStatus>;
   getSdkIdentities: () => Promise<string>;
-  dispatchEventWithResponseCallback: (event: Event) => Promise<Event>;
+  dispatchEvent: (event: Event) => Promise<boolean>;
+  dispatchEventWithResponseCallback: (event: Event, timeout:Number) => Promise<Event>;
   trackAction: (action?: string, contextData?: Record<string, any>) => void;
   trackState: (state?: string, contextData?: Record<string, string>) => void;
   setAdvertisingIdentifier: (advertisingIdentifier?: string) => void;
@@ -145,6 +146,17 @@ const MobileCore: IMobileCore = {
     return RCTAEPCore.getSdkIdentities();
   },
 
+   /**
+   * Called by the extension public API to dispatch an event for other extensions or the internal SDK to consume.
+   * Any events dispatched by this call will not be processed until after `start` has been called.
+   *
+   * @param event Required parameter with {@link Event} instance to be dispatched. Should not be nil
+   * @return true if the the event dispatching operation succeeded, otherwise the promise will return an error
+   */
+   dispatchEvent(event: Event): Promise<boolean> {
+    return RCTAEPCore.dispatchEvent(event);
+  },
+
   /**
    * This method will be used when the provided {@code Event} is used as a trigger and a response event
    * is expected in return.
@@ -154,8 +166,8 @@ const MobileCore: IMobileCore = {
    * @return Promise a promise that resolves with {@link Event}
    *
    */
-  dispatchEventWithResponseCallback(event: Event): Promise<Event> {
-    return RCTAEPCore.dispatchEventWithResponseCallback(event);
+  dispatchEventWithResponseCallback(event: Event, timeout: Number): Promise<Event> {
+    return RCTAEPCore.dispatchEventWithResponseCallback(event, timeout);
   },
 
   /**

--- a/packages/core/ts/MobileCore.ts
+++ b/packages/core/ts/MobileCore.ts
@@ -166,8 +166,8 @@ const MobileCore: IMobileCore = {
    * @return Promise a promise that resolves with {@link Event}
    *
    */
-  dispatchEventWithResponseCallback(event: Event, timeout: Number): Promise<Event> {
-    return RCTAEPCore.dispatchEventWithResponseCallback(event, timeout);
+  dispatchEventWithResponseCallback(event: Event, timeoutMS: Number): Promise<Event> {
+    return RCTAEPCore.dispatchEventWithResponseCallback(event, timeoutMS);
   },
 
   /**

--- a/packages/core/ts/MobileCore.ts
+++ b/packages/core/ts/MobileCore.ts
@@ -150,10 +150,10 @@ const MobileCore: IMobileCore = {
    * Called by the extension public API to dispatch an event for other extensions or the internal SDK to consume.
    * Any events dispatched by this call will not be processed until after `start` has been called.
    *
-   * @param event Required parameter with {@link Event} instance to be dispatched. Should not be nil
-   * @return true if the the event dispatching operation succeeded, otherwise the promise will return an error
+   * @param event Required parameter with {@link Event} instance to be dispatched. Should not be nil.
+   * @return true if the the event dispatching operation succeeded, otherwise the promise will return an error.
    */
-   dispatchEvent(event: Event): Promise<boolean> {
+  dispatchEvent(event: Event): Promise<boolean> {
     return RCTAEPCore.dispatchEvent(event);
   },
 

--- a/packages/core/ts/MobileCore.ts
+++ b/packages/core/ts/MobileCore.ts
@@ -163,6 +163,7 @@ const MobileCore: IMobileCore = {
    * <p>
    *
    * @param event required parameter, {@link Event} instance to be dispatched, used as a trigger
+   * @param timeoutMS the timeout specified in milliseconds
    * @return Promise a promise that resolves with {@link Event}
    *
    */

--- a/packages/core/ts/MobileCore.ts
+++ b/packages/core/ts/MobileCore.ts
@@ -25,7 +25,7 @@ interface IMobileCore {
   getPrivacyStatus: () => Promise<PrivacyStatus>;
   getSdkIdentities: () => Promise<string>;
   dispatchEvent: (event: Event) => Promise<boolean>;
-  dispatchEventWithResponseCallback: (event: Event, timeout:Number) => Promise<Event>;
+  dispatchEventWithResponseCallback: (event: Event, timeoutMS:Number) => Promise<Event>;
   trackAction: (action?: string, contextData?: Record<string, any>) => void;
   trackState: (state?: string, contextData?: Record<string, string>) => void;
   setAdvertisingIdentifier: (advertisingIdentifier?: string) => void;

--- a/packages/messaging/RCTAEPMessaging.podspec
+++ b/packages/messaging/RCTAEPMessaging.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author       = "Adobe Experience Platform SDK Team"
   s.homepage     = "https://github.com/adobe/aepsdk-react-native"
   s.license      = "Apache 2.0 License"
-  s.platform     = :ios, '11.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => "https://github.com/adobe/aepsdk-react-native.git", :tag => "#{s.version}" }
   s.source_files = "ios/**/*.{h,m,mm,swift}"
   s.swift_version = '5.0'

--- a/packages/messaging/RCTAEPMessaging.podspec
+++ b/packages/messaging/RCTAEPMessaging.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author       = "Adobe Experience Platform SDK Team"
   s.homepage     = "https://github.com/adobe/aepsdk-react-native"
   s.license      = "Apache 2.0 License"
-  s.platform     = :ios, '12.0'
+  s.platform     = :ios, '11.0'
   s.source       = { :git => "https://github.com/adobe/aepsdk-react-native.git", :tag => "#{s.version}" }
   s.source_files = "ios/**/*.{h,m,mm,swift}"
   s.swift_version = '5.0'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add dispatchEventWithResponseCallback(event: Event, timeoutMS: Number): Promise<Event> ()

Remove dispatchEventWithResponseCallback(event: Event): Promise<Event> ()

Including few changes from the earlier PR review.
Add dispatchEvent API back

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
