### PR TITLE
Add message.show usage in sample app

### DIFF
--- a/apps/AEPSampleAppNewArchEnabled/app/MessagingView.tsx
+++ b/apps/AEPSampleAppNewArchEnabled/app/MessagingView.tsx
@@ -30,7 +30,6 @@ import { useRouter } from 'expo-router';
 const SURFACES = ['android-cbe-preview', 'cbe/json', 'android-cc'];
 const SURFACES_WITH_CONTENT_CARDS = ['android-cc'];
 
-
 const messagingExtensionVersion = async () => {
   const version = await Messaging.extensionVersion();
   console.log(`AdobeExperienceSDK: Messaging version: ${version}`);
@@ -53,8 +52,21 @@ const setMessagingDelegate = () => {
         console.log('Result:', result);
       });
     },
-    shouldShowMessage: () => true,
-    shouldSaveMessage: () => true,
+    shouldShowMessage: msg => {
+      const msgId = msg.id; // use this message id to save the message in the cache
+      console.log('msgId', msgId);
+
+      // return true to show the message else return false to suppress the message
+      // if you want to save the message in order to show it later, set shouldSaveMessage to true
+      return true; 
+    },
+    shouldSaveMessage: msg => {
+      const msgId = msg.id; // use this message id to save the message in the cache
+      console.log('msgId', msgId);
+
+      // return true to save the message in the cache else return false to not save the message
+      return true; 
+    },
     urlLoaded: (url, message) => console.log(url, message),
   });
   console.log('messaging delegate set');
@@ -81,6 +93,13 @@ const getLatestMessage = async () => {
   const message = await Messaging.getLatestMessage();
   console.log('Latest Message:', message);
 };
+
+const showMessage = async () => {
+  const messageId = 'MESSAGE_ID'; // replace MESSAGE_ID with the id of the message you want to show
+  const message = new Message({id: messageId, autoTrack: true}); 
+  message.show();
+  console.log(`message with id ${messageId} shown`);
+}
 
 // this method can be used to track click interactions with content cards
 const trackContentCardInteraction = async () => {
@@ -159,6 +178,7 @@ function MessagingView() {
         />
         <Button title="getCachedMessages()" onPress={getCachedMessages} />
         <Button title="getLatestMessage()" onPress={getLatestMessage} />
+        <Button title="showMessage()" onPress={showMessage} />
         <Button title="trackAction()" onPress={trackAction} />
         <Button title="trackPropositionInteraction()" onPress={trackContentCardInteraction} />
         <Button title="trackContentCardDisplay()" onPress={trackContentCardDisplay} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Update sample app with usage for `message.show`
-  Add usage for shouldShowMessage and shouldSaveMessage

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Sample app update

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
